### PR TITLE
Fixed for new builds of Dokuwiki

### DIFF
--- a/action/findtemplate.php
+++ b/action/findtemplate.php
@@ -11,7 +11,7 @@ if (!defined('DOKU_INC')) die();
 
 class action_plugin_templatebyname_findtemplate extends DokuWiki_Action_Plugin {
 
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
 
        $controller->register_hook('COMMON_PAGETPL_LOAD', 'BEFORE', $this, 'handle_common_pagetpl_load');
 


### PR DESCRIPTION
From 2018 handle variables are "&" by default, so "&" here must be deleted